### PR TITLE
Add zypper, apt full upgrade

### DIFF
--- a/.bash_aliases
+++ b/.bash_aliases
@@ -69,15 +69,17 @@ alias cls="clear;lsm"
 if [ ! -z "$(which pacman)" ]; then
   alias update="sudo pacman -Syyu"
 elif [ ! -z "$(which apt)" ]; then
-  alias update="sudo apt update && sudo apt upgrade"
+  alias update="sudo apt update && sudo apt upgrade && sudo apt full-upgrade"
 elif [ ! -z "$(which apt-get)" ]; then
-  alias update ="sudo apt-get update && sudo apt-get upgrade"
+  alias update ="sudo apt-get update && sudo apt-get upgrade && sudo apt-get dist-upgrade"
 elif [ ! -z "$(which dnf)" ]; then
   alias update="sudo dnf upgrade"
 elif [ ! -z "$(which yum)" ]; then
   alias update="su -c 'yum update'"
 elif [ ! -z "$(which brew)" ]; then
   alias update="brew update && brew upgrade"
+elif [ ! -z "$(which zypper)" ]; then
+  alias update="sudo zypper update"
 fi
 
 ### ports: lists all ports open and which programs are using them


### PR DESCRIPTION
Added zypper (openSUSE) to the .bashrc "update" aliases and changed the apt alias to perform "full upgrades" by removing installed packages if needed to update the system.